### PR TITLE
Added adjustsFontSizeToFit to props adn context provider

### DIFF
--- a/__tests__/__snapshots__/kitchen-sink-test.tsx.snap
+++ b/__tests__/__snapshots__/kitchen-sink-test.tsx.snap
@@ -8112,11 +8112,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
           }
         >
           <Text
-            adjustsFontSizeToFit={true}
             allowFontScaling={true}
             collapsable={false}
             maxFontSizeMultiplier={100}
-            minimumFontScale={0.01}
             numberOfLines={1}
             style={
               Object {
@@ -8139,11 +8137,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
-            adjustsFontSizeToFit={true}
             allowFontScaling={true}
             collapsable={false}
             maxFontSizeMultiplier={100}
-            minimumFontScale={0.01}
             numberOfLines={1}
             style={
               Object {
@@ -8168,11 +8164,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             3
           </Text>
           <Text
-            adjustsFontSizeToFit={true}
             allowFontScaling={true}
             collapsable={false}
             maxFontSizeMultiplier={100}
-            minimumFontScale={0.01}
             numberOfLines={1}
             style={
               Object {

--- a/__tests__/__snapshots__/kitchen-sink-test.tsx.snap
+++ b/__tests__/__snapshots__/kitchen-sink-test.tsx.snap
@@ -11,6 +11,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
   }
 >
   <Text
+    allowFontScaling={true}
+    maxFontSizeMultiplier={100}
     style={
       Array [
         Object {
@@ -96,6 +98,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -540,6 +544,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -1236,6 +1242,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -2130,6 +2138,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -2332,6 +2342,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -2430,7 +2442,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               >
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   onLayout={[Function]}
                   style={
@@ -2465,7 +2477,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   style={
                     Object {
@@ -2499,8 +2511,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
               </View>
               <TextInput
+                allowFontScaling={true}
                 editable={true}
-                maxFontSizeMultiplier={1.5}
+                maxFontSizeMultiplier={100}
                 multiline={false}
                 onBlur={[Function]}
                 onChangeText={[Function]}
@@ -2636,6 +2649,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -3077,6 +3092,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -4167,6 +4184,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -4373,6 +4392,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -4575,6 +4596,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -4635,6 +4658,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -4681,6 +4706,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -4737,6 +4764,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -4783,6 +4812,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -4839,6 +4870,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -4885,6 +4918,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -4941,6 +4976,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -4987,6 +5024,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -5017,6 +5056,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
     </View>
   </View>
   <Text
+    allowFontScaling={true}
+    maxFontSizeMultiplier={100}
     style={
       Array [
         Object {
@@ -5102,6 +5143,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -5979,6 +6022,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -7720,6 +7765,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -8078,6 +8125,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -8191,7 +8240,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             8
           </Text>
           <Text
+            allowFontScaling={true}
             collapsable={false}
+            maxFontSizeMultiplier={100}
             numberOfLines={1}
             style={
               Object {
@@ -8214,7 +8265,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
+            allowFontScaling={true}
             collapsable={false}
+            maxFontSizeMultiplier={100}
             numberOfLines={1}
             style={
               Object {
@@ -8239,7 +8292,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             3
           </Text>
           <Text
+            allowFontScaling={true}
             collapsable={false}
+            maxFontSizeMultiplier={100}
             numberOfLines={1}
             style={
               Object {
@@ -8327,6 +8382,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -8415,6 +8472,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   }
                 >
                   <Text
+                    allowFontScaling={true}
+                    maxFontSizeMultiplier={100}
                     style={
                       Array [
                         Object {
@@ -9422,6 +9481,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                     }
                   >
                     <Text
+                      allowFontScaling={true}
+                      maxFontSizeMultiplier={100}
                       style={
                         Array [
                           Object {
@@ -9712,7 +9773,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                             }
                           >
                             <Text
-                              maxFontSizeMultiplier={1}
+                              maxFontSizeMultiplier={100}
                               style={
                                 Array [
                                   Object {
@@ -9754,7 +9815,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                             }
                           >
                             <Text
-                              maxFontSizeMultiplier={1}
+                              maxFontSizeMultiplier={100}
                               selectable={false}
                               style={
                                 Array [
@@ -10000,7 +10061,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                             }
                           >
                             <Text
-                              maxFontSizeMultiplier={1}
+                              maxFontSizeMultiplier={100}
                               style={
                                 Array [
                                   Object {
@@ -10042,7 +10103,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                             }
                           >
                             <Text
-                              maxFontSizeMultiplier={1}
+                              maxFontSizeMultiplier={100}
                               selectable={false}
                               style={
                                 Array [
@@ -10286,7 +10347,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                             }
                           >
                             <Text
-                              maxFontSizeMultiplier={1}
+                              maxFontSizeMultiplier={100}
                               style={
                                 Array [
                                   Object {
@@ -10328,7 +10389,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                             }
                           >
                             <Text
-                              maxFontSizeMultiplier={1}
+                              maxFontSizeMultiplier={100}
                               selectable={false}
                               style={
                                 Array [
@@ -12453,6 +12514,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -12493,6 +12556,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -12751,6 +12816,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -13009,6 +13076,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -13267,6 +13336,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -13525,6 +13596,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -13837,6 +13910,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -13877,6 +13952,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -14063,6 +14140,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -14249,6 +14328,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -14435,6 +14516,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -14621,6 +14704,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -14861,6 +14946,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -17002,6 +17089,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -17033,6 +17122,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
           }
         >
           <Text
+            allowFontScaling={true}
+            maxFontSizeMultiplier={100}
             style={
               Array [
                 Object {
@@ -17069,6 +17160,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
+            allowFontScaling={true}
+            maxFontSizeMultiplier={100}
             style={
               Array [
                 Object {
@@ -17105,6 +17198,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
+            allowFontScaling={true}
+            maxFontSizeMultiplier={100}
             style={
               Array [
                 Object {
@@ -17141,6 +17236,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
+            allowFontScaling={true}
+            maxFontSizeMultiplier={100}
             style={
               Array [
                 Object {
@@ -17179,6 +17276,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
+            allowFontScaling={true}
+            maxFontSizeMultiplier={100}
             style={
               Array [
                 Object {
@@ -17217,6 +17316,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
+            allowFontScaling={true}
+            maxFontSizeMultiplier={100}
             style={
               Array [
                 Object {
@@ -17319,6 +17420,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={2}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -18335,6 +18438,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -18656,6 +18761,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -18699,6 +18806,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -18813,6 +18922,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -18892,6 +19003,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -18975,6 +19088,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19089,6 +19204,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19168,6 +19285,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19302,6 +19421,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -19345,6 +19466,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19456,6 +19579,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19567,6 +19692,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19682,6 +19809,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19793,6 +19922,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -19904,6 +20035,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               }
             >
               <Text
+                allowFontScaling={true}
+                maxFontSizeMultiplier={100}
                 style={
                   Array [
                     Object {
@@ -20070,6 +20203,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -20272,6 +20407,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -20474,6 +20611,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -20515,6 +20654,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -20598,6 +20739,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -20681,6 +20824,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -20766,6 +20911,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           >
             <Text
+              allowFontScaling={true}
+              maxFontSizeMultiplier={100}
               style={
                 Array [
                   Object {
@@ -20900,6 +21047,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {
@@ -22282,7 +22431,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               >
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   onLayout={[Function]}
                   style={
@@ -22317,7 +22466,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   style={
                     Object {
@@ -22351,8 +22500,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
               </View>
               <TextInput
+                allowFontScaling={true}
                 editable={true}
-                maxFontSizeMultiplier={1.5}
+                maxFontSizeMultiplier={100}
                 multiline={false}
                 onBlur={[Function]}
                 onChangeText={[Function]}
@@ -22485,7 +22635,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   />
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     style={
                       Object {
@@ -22523,7 +22673,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     onLayout={[Function]}
                     style={
@@ -22557,7 +22707,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     style={
                       Object {
@@ -22590,8 +22740,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                 </View>
                 <TextInput
+                  allowFontScaling={true}
                   editable={true}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   multiline={false}
                   onBlur={[Function]}
                   onChangeText={[Function]}
@@ -22705,7 +22856,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               >
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   onLayout={[Function]}
                   style={
@@ -22740,7 +22891,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   style={
                     Object {
@@ -22774,8 +22925,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
               </View>
               <TextInput
+                allowFontScaling={true}
                 editable={true}
-                maxFontSizeMultiplier={1.5}
+                maxFontSizeMultiplier={100}
                 multiline={false}
                 onBlur={[Function]}
                 onChangeText={[Function]}
@@ -22908,7 +23060,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   />
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     style={
                       Object {
@@ -22946,7 +23098,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     onLayout={[Function]}
                     style={
@@ -22980,7 +23132,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     style={
                       Object {
@@ -23013,8 +23165,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                 </View>
                 <TextInput
+                  allowFontScaling={true}
                   editable={true}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   multiline={false}
                   onBlur={[Function]}
                   onChangeText={[Function]}
@@ -23128,7 +23281,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
               >
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   onLayout={[Function]}
                   style={
@@ -23163,7 +23316,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
                 <Text
                   collapsable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   numberOfLines={1}
                   style={
                     Object {
@@ -23197,8 +23350,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                 </Text>
               </View>
               <TextInput
+                allowFontScaling={true}
                 editable={false}
-                maxFontSizeMultiplier={1.5}
+                maxFontSizeMultiplier={100}
                 multiline={false}
                 onBlur={[Function]}
                 onChangeText={[Function]}
@@ -23331,7 +23485,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   />
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     style={
                       Object {
@@ -23369,7 +23523,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     onLayout={[Function]}
                     style={
@@ -23403,7 +23557,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                   <Text
                     collapsable={false}
-                    maxFontSizeMultiplier={1.5}
+                    maxFontSizeMultiplier={100}
                     numberOfLines={1}
                     style={
                       Object {
@@ -23436,8 +23590,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
                   </Text>
                 </View>
                 <TextInput
+                  allowFontScaling={true}
                   editable={false}
-                  maxFontSizeMultiplier={1.5}
+                  maxFontSizeMultiplier={100}
                   multiline={false}
                   onBlur={[Function]}
                   onChangeText={[Function]}
@@ -23546,6 +23701,8 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={1}
       >
         <Text
+          allowFontScaling={true}
+          maxFontSizeMultiplier={100}
           style={
             Array [
               Object {

--- a/__tests__/__snapshots__/kitchen-sink-test.tsx.snap
+++ b/__tests__/__snapshots__/kitchen-sink-test.tsx.snap
@@ -8112,6 +8112,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
           }
         >
           <Text
+            adjustsFontSizeToFit={true}
             allowFontScaling={true}
             collapsable={false}
             maxFontSizeMultiplier={100}
@@ -8138,6 +8139,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             }
           />
           <Text
+            adjustsFontSizeToFit={true}
             allowFontScaling={true}
             collapsable={false}
             maxFontSizeMultiplier={100}
@@ -8166,6 +8168,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
             3
           </Text>
           <Text
+            adjustsFontSizeToFit={true}
             allowFontScaling={true}
             collapsable={false}
             maxFontSizeMultiplier={100}

--- a/__tests__/__snapshots__/mobile-stepper-test.tsx.snap
+++ b/__tests__/__snapshots__/mobile-stepper-test.tsx.snap
@@ -190,7 +190,9 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
         total={5}
       />
       <Text
+        allowFontScaling={true}
         index={2}
+        maxFontSizeMultiplier={100}
         siblings={
           Array [
             "withTheme(Divider)",

--- a/__tests__/__snapshots__/user-menu-test.tsx.snap
+++ b/__tests__/__snapshots__/user-menu-test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Kitchen sink snapshot Renders correctly and snapShot matches 1`] = `
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
-    statusBarTranslucent={false}
+    statusBarTranslucent={true}
     supportedOrientations={
       Array [
         "portrait",

--- a/components/kitchen-sink.tsx
+++ b/components/kitchen-sink.tsx
@@ -54,7 +54,7 @@ import {
     ThemedTextInput,
     ThemedToggleButton,
 } from '@brightlayer-ui/react-native-components/themed';
-import { ADJUSTS_FONT_SIZE_TO_FIT, DISABLE_FONT_SCALE, MAX_FONT_SCALE, MIN_FONT_SCALE } from '../constants';
+import { DISABLE_FONT_SCALE, MAX_FONT_SCALE } from '../constants';
 const AvatarTestImage = require('../assets/images/test-avatar.png');
 
 const MusicRoute = (): JSX.Element => <Subtitle1>Music</Subtitle1>;
@@ -508,17 +508,13 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             size={24}
                             visible
                             allowFontScaling={!DISABLE_FONT_SCALE}
-                            adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
                             maxFontSizeMultiplier={MAX_FONT_SCALE}
-                            minimumFontScale={MIN_FONT_SCALE}
                         ></Badge>
                         <Badge
                             size={24}
                             visible
                             allowFontScaling={!DISABLE_FONT_SCALE}
-                            adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
                             maxFontSizeMultiplier={MAX_FONT_SCALE}
-                            minimumFontScale={MIN_FONT_SCALE}
                         >
                             3
                         </Badge>
@@ -526,9 +522,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             size={40}
                             visible
                             allowFontScaling={!DISABLE_FONT_SCALE}
-                            adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
                             maxFontSizeMultiplier={MAX_FONT_SCALE}
-                            minimumFontScale={MIN_FONT_SCALE}
                         >
                             8
                         </Badge>

--- a/components/kitchen-sink.tsx
+++ b/components/kitchen-sink.tsx
@@ -54,7 +54,7 @@ import {
     ThemedTextInput,
     ThemedToggleButton,
 } from '@brightlayer-ui/react-native-components/themed';
-import { DISABLE_FONT_SCALE, MAX_FONT_SCALE, MIN_FONT_SCALE } from '../constants';
+import { ADJUSTS_FONT_SIZE_TO_FIT, DISABLE_FONT_SCALE, MAX_FONT_SCALE, MIN_FONT_SCALE } from '../constants';
 const AvatarTestImage = require('../assets/images/test-avatar.png');
 
 const MusicRoute = (): JSX.Element => <Subtitle1>Music</Subtitle1>;
@@ -508,6 +508,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             size={24}
                             visible
                             allowFontScaling={!DISABLE_FONT_SCALE}
+                            adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
                             maxFontSizeMultiplier={MAX_FONT_SCALE}
                             minimumFontScale={MIN_FONT_SCALE}
                         ></Badge>
@@ -515,6 +516,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             size={24}
                             visible
                             allowFontScaling={!DISABLE_FONT_SCALE}
+                            adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
                             maxFontSizeMultiplier={MAX_FONT_SCALE}
                             minimumFontScale={MIN_FONT_SCALE}
                         >
@@ -524,6 +526,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             size={40}
                             visible
                             allowFontScaling={!DISABLE_FONT_SCALE}
+                            adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
                             maxFontSizeMultiplier={MAX_FONT_SCALE}
                             minimumFontScale={MIN_FONT_SCALE}
                         >

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,4 +1,2 @@
 export const MAX_FONT_SCALE = 100;
-export const MIN_FONT_SCALE = 0.01;
 export const DISABLE_FONT_SCALE = false;
-export const ADJUSTS_FONT_SIZE_TO_FIT = true;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,3 +1,4 @@
 export const MAX_FONT_SCALE = 100;
 export const MIN_FONT_SCALE = 0.01;
 export const DISABLE_FONT_SCALE = false;
+export const ADJUSTS_FONT_SIZE_TO_FIT = true;

--- a/index.tsx
+++ b/index.tsx
@@ -10,7 +10,7 @@ import React, { useState } from 'react';
 import { ThemeContext, ThemeType } from './contexts/ThemeContext';
 import { blue, blueDark } from '@brightlayer-ui/react-native-themes';
 import { FontScaleProvider } from '@brightlayer-ui/react-native-components';
-import { ADJUSTS_FONT_SIZE_TO_FIT, DISABLE_FONT_SCALE, MAX_FONT_SCALE, MIN_FONT_SCALE } from './constants';
+import { DISABLE_FONT_SCALE, MAX_FONT_SCALE } from './constants';
 
 const wrapper = (): JSX.Element => {
     const [theme, setTheme] = useState<ThemeType>('light');
@@ -18,12 +18,7 @@ const wrapper = (): JSX.Element => {
     return (
         <ThemeContext.Provider value={{ theme, setTheme }}>
             <PaperProvider theme={theme === 'light' ? blue : blueDark}>
-                <FontScaleProvider
-                    disableScaling={DISABLE_FONT_SCALE}
-                    adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
-                    maxScale={MAX_FONT_SCALE}
-                    minScale={MIN_FONT_SCALE}
-                >
+                <FontScaleProvider disableScaling={DISABLE_FONT_SCALE} maxScale={MAX_FONT_SCALE}>
                     <MainRouter />
                 </FontScaleProvider>
             </PaperProvider>

--- a/index.tsx
+++ b/index.tsx
@@ -10,7 +10,7 @@ import React, { useState } from 'react';
 import { ThemeContext, ThemeType } from './contexts/ThemeContext';
 import { blue, blueDark } from '@brightlayer-ui/react-native-themes';
 import { FontScaleProvider } from '@brightlayer-ui/react-native-components';
-import { DISABLE_FONT_SCALE, MAX_FONT_SCALE, MIN_FONT_SCALE } from './constants';
+import { ADJUSTS_FONT_SIZE_TO_FIT, DISABLE_FONT_SCALE, MAX_FONT_SCALE, MIN_FONT_SCALE } from './constants';
 
 const wrapper = (): JSX.Element => {
     const [theme, setTheme] = useState<ThemeType>('light');
@@ -20,6 +20,7 @@ const wrapper = (): JSX.Element => {
             <PaperProvider theme={theme === 'light' ? blue : blueDark}>
                 <FontScaleProvider
                     disableScaling={DISABLE_FONT_SCALE}
+                    adjustsFontSizeToFit={ADJUSTS_FONT_SIZE_TO_FIT}
                     maxScale={MAX_FONT_SCALE}
                     minScale={MIN_FONT_SCALE}
                 >

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "@brightlayer-ui/colors": "^3.1.1",
         "@brightlayer-ui/icons-svg": "^1.11.0",
-        "@brightlayer-ui/react-native-components": "^6.0.3",
+        "@brightlayer-ui/react-native-components": "^7.1.0-beta.0",
         "@brightlayer-ui/react-native-progress-icons": "^1.0.2",
         "@brightlayer-ui/react-native-themes": "^6.0.0",
         "@brightlayer-ui/react-native-vector-icons": "^2.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,16 +807,16 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-native-components@^6.0.3":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.3.tgz#fcf8aa5c380d81041aeccc93e0d84a915452ba71"
-  integrity sha512-ZRsoOnDLn5E+ZejG3OXzMv+YFG1pfBcq5sLkTSQvfL9Vnv5Co4o/QIYFPjztNt46RaUCRk20+4cqhrO5IVPsBA==
+"@brightlayer-ui/react-native-components@^7.1.0-beta.0":
+  version "7.1.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-7.1.0-beta.0.tgz#1801d35389c123b82d11bbcde49cea3dbd46cd87"
+  integrity sha512-MEdApqwHlwFjhkNhev+h0aH1nW+3GmYPL6Gtau8klLkOTKTX8MzYUmsInF4BlgpW88TXWdHcKn9pIAe+69rI3g==
   dependencies:
-    "@brightlayer-ui/colors" "^3.0.0"
-    color "^3.1.2"
-    react-native-collapsible "^1.5.3"
-    react-native-keyboard-aware-scroll-view "^0.8.0"
-    react-native-modal ">=11.6.1"
+    "@brightlayer-ui/colors" "^3.1.1"
+    color "^4.2.3"
+    react-native-collapsible "^1.6.0"
+    react-native-keyboard-aware-scroll-view "^0.9.5"
+    react-native-modal ">=13.0.1"
 
 "@brightlayer-ui/react-native-progress-icons@^1.0.2":
   version "1.0.2"
@@ -6586,7 +6586,7 @@ react-native-codegen@^0.70.4:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
-react-native-collapsible@^1.5.3, react-native-collapsible@^1.6.0:
+react-native-collapsible@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/react-native-collapsible/-/react-native-collapsible-1.6.0.tgz#ca261ffff16914f872059bb0972e3a78c4b37f9c"
   integrity sha512-beZjdgbT9Y/Pg591Xy5XkKG20HffJiVad4n9bfcUF/f783A+tvOVXnqvbS58Lkaym93mi4jcDPMuW9Vc1t6rqg==
@@ -6612,15 +6612,15 @@ react-native-iphone-x-helper@^1.0.3, react-native-iphone-x-helper@^1.3.0, react-
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
   integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
-react-native-keyboard-aware-scroll-view@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.8.0.tgz#00bcaa38c91323913bb7a733059ad2bc4875f88c"
-  integrity sha512-gPfhgHQI/z7Cc5aeNOEmK0b250QkAeU6V+4oH8EC7mmFneEKn6MAIDjpoiwqt6bV+lFJPABXfx9MtrRmtCeJ/Q==
+react-native-keyboard-aware-scroll-view@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz#e2e9665d320c188e6b1f22f151b94eb358bf9b71"
+  integrity sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==
   dependencies:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
-react-native-modal@>=11.6.1, react-native-modal@^13.0.1:
+react-native-modal@>=13.0.1, react-native-modal@^13.0.1:
   version "13.0.1"
   resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-13.0.1.tgz#691f1e646abb96fa82c1788bf18a16d585da37cd"
   integrity sha512-UB+mjmUtf+miaG/sDhOikRfBOv0gJdBU2ZE1HtFWp6UixW9jCk/bhGdHUgmZljbPpp0RaO/6YiMmQSSK3kkMaw==


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-3647

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Removed min scale from font scale context

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

<img width="475" alt="Screenshot 2023-01-10 at 1 50 24 PM" src="https://user-images.githubusercontent.com/120575281/211498230-d9882dc9-6601-4d2b-b4fb-11c5c6e1b70d.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
- Checkout to [feature/handle-font-scale-min-scale](https://github.com/etn-ccis/blui-react-native-component-library/tree/feature/handle-font-scale-min-scale) branch in blui-react-native-component-library
- This PR is raised to target the min font scale. **We will be removing min scale**
- yarn start:showcase

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

**Note: Please merge this after https://github.com/etn-ccis/blui-react-native-component-library/pull/321 gets merged**

**DO NOT MERGE till we get @brightlayer-ui/react-native-components 7.0.1-beta.1** published.