### PR TITLE
Update color/theme dependencies

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -56,7 +56,7 @@ import {
 import BLUIIcon from '@brightlayer-ui/react-native-vector-icons';
 import { ScoreCardExample } from './ScoreCardExample';
 import { MobileStepperExample } from './MobileStepperExample';
-import { BLUIColors } from '@brightlayer-ui/colors';
+import * as Colors from '@brightlayer-ui/colors';
 
 const PublicDomainAlice = require('../assets/images/public-domain-alice.png');
 
@@ -547,8 +547,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             title={'Title'}
                             icon={{ family: 'brightlayer-ui', name: 'leaf' }}
                             subtitle={'Subtitle'}
-                            statusColor={BLUIColors.red[500]}
-                            backgroundColor={BLUIColors.blue[50]}
+                            statusColor={Colors.error[40]}
+                            backgroundColor={Colors.primary[40]}
                             avatar
                             divider={'partial'}
                             chevron

--- a/components/MobileStepperExample.tsx
+++ b/components/MobileStepperExample.tsx
@@ -85,7 +85,7 @@ export const MobileStepperExample: React.FC = () => {
                     </Button>
                 }
                 variant={mobileStepperVariant}
-                activeColor={Colors.blue[500]}
+                activeColor={Colors.primary[50]}
             />
         </Card>
     );

--- a/components/ScoreCardExample.tsx
+++ b/components/ScoreCardExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Hero, InfoListItem, ScoreCard } from '@brightlayer-ui/react-native-components';
-import { BLUIColors } from '@brightlayer-ui/colors';
+import * as Colors from '@brightlayer-ui/colors';
 import { useTheme } from 'react-native-paper';
 
 export const ScoreCardExample: React.FC = () => {
@@ -18,7 +18,7 @@ export const ScoreCardExample: React.FC = () => {
                     iconBackgroundColor={theme.colors.surface}
                     label={'Score'}
                     iconSize={48}
-                    iconColor={BLUIColors.green[500]}
+                    iconColor={Colors.purple[40]}
                     ChannelValueProps={{
                         value: 98,
                         units: '/100',

--- a/ios/BluiReactNativeShowcaseDemo.xcodeproj/project.pbxproj
+++ b/ios/BluiReactNativeShowcaseDemo.xcodeproj/project.pbxproj
@@ -593,7 +593,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -666,7 +666,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,7 +34,7 @@ target 'BluiReactNativeShowcaseDemo' do
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.
-    :hermes_enabled => flags[false],
+    :hermes_enabled => false,
     :fabric_enabled => flags[:fabric_enabled],
     # Enables Flipper.
     #

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,7 +34,7 @@ target 'BluiReactNativeShowcaseDemo' do
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.
-    :hermes_enabled => flags[:hermes_enabled],
+    :hermes_enabled => flags[false],
     :fabric_enabled => flags[:fabric_enabled],
     # Enables Flipper.
     #

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -70,9 +70,6 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.72.3):
-    - hermes-engine/Pre-built (= 0.72.3)
-  - hermes-engine/Pre-built (0.72.3)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -86,12 +83,6 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCT-Folly/Futures (2021.07.22.00):
-    - boost
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - libevent
   - RCTRequired (0.72.3)
   - RCTTypeSafety (0.72.3):
     - FBLazyVector (= 0.72.3)
@@ -115,11 +106,11 @@ PODS:
     - DoubleConversion
     - FBReactNativeSpec
     - glog
-    - hermes-engine
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
@@ -128,11 +119,10 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Core (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 0.72.3)
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -142,11 +132,10 @@ PODS:
     - Yoga
   - React-Core/CoreModulesHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -156,10 +145,9 @@ PODS:
     - Yoga
   - React-Core/Default (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -169,12 +157,11 @@ PODS:
     - Yoga
   - React-Core/DevSupport (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 0.72.3)
     - React-Core/RCTWebSocket (= 0.72.3)
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector (= 0.72.3)
@@ -185,11 +172,10 @@ PODS:
     - Yoga
   - React-Core/RCTActionSheetHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -199,11 +185,10 @@ PODS:
     - Yoga
   - React-Core/RCTAnimationHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -213,11 +198,10 @@ PODS:
     - Yoga
   - React-Core/RCTBlobHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -227,11 +211,10 @@ PODS:
     - Yoga
   - React-Core/RCTImageHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -241,11 +224,10 @@ PODS:
     - Yoga
   - React-Core/RCTLinkingHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -255,11 +237,10 @@ PODS:
     - Yoga
   - React-Core/RCTNetworkHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -269,11 +250,10 @@ PODS:
     - Yoga
   - React-Core/RCTSettingsHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -283,11 +263,10 @@ PODS:
     - Yoga
   - React-Core/RCTTextHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -297,11 +276,10 @@ PODS:
     - Yoga
   - React-Core/RCTVibrationHeaders (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -311,11 +289,10 @@ PODS:
     - Yoga
   - React-Core/RCTWebSocket (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default (= 0.72.3)
     - React-cxxreact
-    - React-hermes
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-perflogger
@@ -337,7 +314,6 @@ PODS:
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 0.72.3)
     - React-debug (= 0.72.3)
@@ -347,27 +323,19 @@ PODS:
     - React-perflogger (= 0.72.3)
     - React-runtimeexecutor (= 0.72.3)
   - React-debug (0.72.3)
-  - React-hermes (0.72.3):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.72.3)
-    - React-jsi
-    - React-jsiexecutor (= 0.72.3)
-    - React-jsinspector (= 0.72.3)
-    - React-perflogger (= 0.72.3)
+  - React-jsc (0.72.3):
+    - React-jsc/Fabric (= 0.72.3)
+    - React-jsi (= 0.72.3)
+  - React-jsc/Fabric (0.72.3):
+    - React-jsi (= 0.72.3)
   - React-jsi (0.72.3):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
   - React-jsiexecutor (0.72.3):
     - DoubleConversion
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-cxxreact (= 0.72.3)
     - React-jsi (= 0.72.3)
@@ -378,7 +346,6 @@ PODS:
   - react-native-safe-area-context (4.7.2):
     - React-Core
   - React-NativeModulesApple (0.72.3):
-    - hermes-engine
     - React-callinvoker
     - React-Core
     - React-cxxreact
@@ -402,14 +369,13 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - React-CoreModules
-    - React-hermes
+    - React-jsc
     - React-NativeModulesApple
     - React-RCTImage
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
   - React-RCTBlob (0.72.3):
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Codegen (= 0.72.3)
     - React-Core/RCTBlobHeaders (= 0.72.3)
@@ -457,7 +423,6 @@ PODS:
     - React-jsi (= 0.72.3)
   - React-runtimescheduler (0.72.3):
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker
     - React-debug
@@ -470,7 +435,6 @@ PODS:
   - ReactCommon/turbomodule/bridging (0.72.3):
     - DoubleConversion
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 0.72.3)
     - React-cxxreact (= 0.72.3)
@@ -480,7 +444,6 @@ PODS:
   - ReactCommon/turbomodule/core (0.72.3):
     - DoubleConversion
     - glog
-    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-callinvoker (= 0.72.3)
     - React-cxxreact (= 0.72.3)
@@ -529,8 +492,6 @@ DEPENDENCIES:
   - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.182.0)
   - FlipperKit/SKIOSNetworkPlugin (= 0.182.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - libevent (~> 2.1.12)
   - OpenSSL-Universal (= 1.1.1100)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -544,7 +505,7 @@ DEPENDENCIES:
   - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
   - React-debug (from `../node_modules/react-native/ReactCommon/react/debug`)
-  - React-hermes (from `../node_modules/react-native/ReactCommon/hermes`)
+  - React-jsc (from `../node_modules/react-native/ReactCommon/jsc`)
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
@@ -602,9 +563,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
-  hermes-engine:
-    :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
-    :tag: hermes-2023-03-20-RNv0.72.0-49794cfc7c81fb8f69fd60c3bbf85a7480cc5a77
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -625,8 +583,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/cxxreact"
   React-debug:
     :path: "../node_modules/react-native/ReactCommon/react/debug"
-  React-hermes:
-    :path: "../node_modules/react-native/ReactCommon/hermes"
+  React-jsc:
+    :path: "../node_modules/react-native/ReactCommon/jsc"
   React-jsi:
     :path: "../node_modules/react-native/ReactCommon/jsi"
   React-jsiexecutor:
@@ -700,7 +658,6 @@ SPEC CHECKSUMS:
   FlipperKit: 2efad7007d6745a3f95e4034d547be637f89d3f6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 10fbd3f62405c41ea07e71973ea61e1878d07322
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
@@ -708,23 +665,23 @@ SPEC CHECKSUMS:
   RCTTypeSafety: cb09f3e4747b6d18331a15eb05271de7441ca0b3
   React: 13109005b5353095c052f26af37413340ccf7a5d
   React-callinvoker: c8c87bce983aa499c13cb06d4447c025a35274d6
-  React-Codegen: 712d523524d89d71f1cf7cc624854941be983c4d
-  React-Core: 688f88b7f3a3d30b4848036223f8b07102c687e5
+  React-Codegen: 264b1022063f27ccccfd38f4ce29cc8217b1e812
+  React-Core: 2688f9f07b65379352fe49670458e8e0d683e336
   React-CoreModules: 63c063a3ade8fb3b1bec5fd9a50f17b0421558c6
-  React-cxxreact: 37765b4975541105b2a3322a4b473417c158c869
+  React-cxxreact: 55d0f7cb6b4cc09ba9190797f1da87182d1a2fb6
   React-debug: 51f11ef8db14b47f24e71c42a4916d4192972156
-  React-hermes: 935ae71fb3d7654e947beba8498835cd5e479707
-  React-jsi: ec628dc7a15ffea969f237b0ea6d2fde212b19dd
-  React-jsiexecutor: 59d1eb03af7d30b7d66589c410f13151271e8006
+  React-jsc: 0db8e8cc2074d979c37ffa7b8d7c914833960497
+  React-jsi: 58677ff4848ceb6aeb9118fe03448a843ea5e16a
+  React-jsiexecutor: 2c15ba1bace70177492368d5180b564f165870fd
   React-jsinspector: b511447170f561157547bc0bef3f169663860be7
   React-logger: c5b527272d5f22eaa09bb3c3a690fee8f237ae95
   react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
-  React-NativeModulesApple: c57f3efe0df288a6532b726ad2d0322a9bf38472
+  React-NativeModulesApple: bfbb84f3e6a1b919791b57303524de557ba45fef
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
   React-RCTActionSheet: c0b62af44e610e69d9a2049a682f5dba4e9dff17
   React-RCTAnimation: f9bf9719258926aea9ecb8a2aa2595d3ff9a6022
-  React-RCTAppDelegate: e5ac35d4dbd1fae7df3a62b47db04b6a8d151592
-  React-RCTBlob: c4f1e69a6ef739aa42586b876d637dab4e3b5bed
+  React-RCTAppDelegate: 41b778ee7b1f76566fa1b1ebffe9837a01a3a18d
+  React-RCTBlob: afc0e14539eb7a76a713332340aee21bf23c76b5
   React-RCTImage: e5798f01aba248416c02a506cf5e6dfcba827638
   React-RCTLinking: f5b6227c879e33206f34e68924c458f57bbb96d9
   React-RCTNetwork: d5554fbfac1c618da3c8fa29933108ea22837788
@@ -733,9 +690,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 388ac0e1455420895d1ca2548401eed964b038a6
   React-rncore: 755a331dd67b74662108f2d66a384454bf8dc1a1
   React-runtimeexecutor: 369ae9bb3f83b65201c0c8f7d50b72280b5a1dbc
-  React-runtimescheduler: 837c1bebd2f84572db17698cd702ceaf585b0d9a
+  React-runtimescheduler: af0b24628c1d543a3f87251c9efa29c5a589e08a
   React-utils: bcb57da67eec2711f8b353f6e3d33bd8e4b2efa3
-  ReactCommon: 3ccb8fb14e6b3277e38c73b0ff5e4a1b8db017a9
+  ReactCommon: d7d63a5b3c3ff29304a58fc8eb3b4f1b077cd789
   RNBLUIVectorIcons: 2198bfdf9aa57f08d56360e85ca6568821b67b5e
   RNGestureHandler: 38aa38413896620338948fbb5c90579a7b1c3fde
   RNScreens: 85d3880b52d34db7b8eeebe2f1a0e807c05e69fa
@@ -745,6 +702,6 @@ SPEC CHECKSUMS:
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 2fc4ee686a97e318fa30a4ddd068c328067d667c
+PODFILE CHECKSUM: 180f82535da62963147e01029a0fabf7840f6f02
 
 COCOAPODS: 1.12.1

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
         "coverage": "yarn test --coverage --watchAll=false"
     },
     "dependencies": {
-        "@brightlayer-ui/colors": "^3.1.1",
+        "@brightlayer-ui/colors": "4.0.0-alpha.1",
         "@brightlayer-ui/icons-svg": "^1.13.1",
         "@brightlayer-ui/react-native-components": "^7.1.0",
         "@brightlayer-ui/react-native-progress-icons": "^1.0.2",
-        "@brightlayer-ui/react-native-themes": "^6.0.0",
+        "@brightlayer-ui/react-native-themes": "7.0.0-alpha.0",
         "@brightlayer-ui/react-native-vector-icons": "^2.2.0",
         "@types/jest": "^29.5.3",
         "color": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,19 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@brightlayer-ui/colors@^3.0.0", "@brightlayer-ui/colors@^3.1.1":
+"@brightlayer-ui/colors@4.0.0-alpha.0":
+  version "4.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/colors/-/colors-4.0.0-alpha.0.tgz#d23adfe71d53633d96d5ed619a6821fa876cde28"
+  integrity sha512-vyqJgwTK6pU621GuGvjgd/vX+82wxn/LFeL2Kvf8Uxy5EyQ6Y4uYrlJowDwVKkvTsEmKxja4uo3vdnhx6fpElQ==
+  dependencies:
+    "@brightlayer-ui/types" "^2.0.0"
+
+"@brightlayer-ui/colors@4.0.0-alpha.1":
+  version "4.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/colors/-/colors-4.0.0-alpha.1.tgz#5ffe990070e1311343fe9a36a401408010238df0"
+  integrity sha512-ZaDQEQnnVVcGRsC8wnKNFkVXI1kMk7B9FX5eEfG73UriP6YEbJBHztk9sNJDM9SNHgXbKovnLg56odHmoVYBKg==
+
+"@brightlayer-ui/colors@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/colors/-/colors-3.1.1.tgz#7bc86498e30172c410ba4c3237149b16a2eed4c6"
   integrity sha512-fV10E5JDuVGDQ0gCY3pEfDwUo1+lvDFC5pmOAAGpN7YDramS6ggUpJ/LmYavKAudw7FNcaJnPi7tsQWJjvv/7w==
@@ -1203,13 +1215,13 @@
   dependencies:
     color "^3.1.3"
 
-"@brightlayer-ui/react-native-themes@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-6.0.0.tgz#9415041d4b66cf6e06d5db8f387354ab2c03a81e"
-  integrity sha512-vGBuntv0A6tywgQjxwxXcRoV0IjSVVBUMEMqmv7HlH+Uyf5je/yrJczvQOVHOXzMwNm1HnvHXUhuDQ1t7Mhcuw==
+"@brightlayer-ui/react-native-themes@7.0.0-alpha.0":
+  version "7.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-7.0.0-alpha.0.tgz#1bfa8a002ddc1f187e473a5efcc701b2d12de38e"
+  integrity sha512-kjGuHcjWNGI65lbe4sqpDm3XCOnsZ+67aGPH2XTwpdeHaV9jUEeVNF7hv1OTrRRFjQvTAVv8s+q+1tuY7Qtthg==
   dependencies:
-    "@brightlayer-ui/colors" "^3.0.0"
-    color "^3.1.3"
+    "@brightlayer-ui/colors" "4.0.0-alpha.0"
+    color "^4.2.3"
 
 "@brightlayer-ui/react-native-vector-icons@^2.2.0":
   version "2.2.0"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4936.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:
This is to test https://github.com/etn-ccis/blui-react-native-component-library/pull/436

- Update imports on Colors
- Update POD hermes disbaled
- Use @brightlayer-ui/colors": "4.0.0-alpha.1" & "@brightlayer-ui/react-native-themes": "7.0.0-alpha.0"

linting in showcase (kitchensink) dirty

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
