### PR TITLE
Added badge wrapper example to kitchen sink

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -5,7 +5,6 @@ import { StyleSheet, View } from 'react-native';
 import {
     Appbar,
     Avatar,
-    Badge,
     Banner,
     Button,
     BottomNavigation,
@@ -35,6 +34,7 @@ import {
 } from 'react-native-paper';
 import { DISABLE_FONT_SCALE, MAX_FONT_SCALE } from '../constants';
 import {
+    Badge,
     ChannelValue,
     ListItemTag,
     Overline,
@@ -202,6 +202,55 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     actionItems: [{ icon: { name: 'more' }, onPress: () => {} }],
                 }}
             >
+                <Card style={styles.card}>
+                    <View
+                        style={{
+                            justifyContent: 'center',
+                            marginHorizontal: 24,
+                            marginVertical: 24,
+                        }}
+                    >
+                        <Text>Badge</Text>
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                justifyContent: 'space-evenly',
+                                alignItems: 'center',
+                                marginTop: 24,
+                            }}
+                        >
+                            <Badge
+                                size={24}
+                                visible
+                                allowFontScaling={!DISABLE_FONT_SCALE}
+                                maxFontSizeMultiplier={MAX_FONT_SCALE}
+                            />
+                            <Badge
+                                size={24}
+                                visible
+                                allowFontScaling={!DISABLE_FONT_SCALE}
+                                maxFontSizeMultiplier={MAX_FONT_SCALE}
+                            >
+                                3
+                            </Badge>
+                            <Badge
+                                size={40}
+                                visible
+                                allowFontScaling={!DISABLE_FONT_SCALE}
+                                maxFontSizeMultiplier={MAX_FONT_SCALE}
+                            >
+                                8
+                            </Badge>
+                            <Badge size={24} visible />
+                            <Badge size={24} visible>
+                                3
+                            </Badge>
+                            <Badge size={40} visible>
+                                8
+                            </Badge>
+                        </View>
+                    </View>
+                </Card>
                 <Card style={styles.card}>
                     <Card.Title title="grades" />
                     <Card.Content>
@@ -1048,55 +1097,6 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             <Avatar.Icon size={40} icon="account-circle" />
                             <Avatar.Image size={40} source={PublicDomainAlice} />
                             <Avatar.Text size={40} label="PX" />
-                        </View>
-                    </View>
-                </Card>
-                <Card style={styles.card}>
-                    <View
-                        style={{
-                            justifyContent: 'center',
-                            marginHorizontal: 24,
-                            marginVertical: 24,
-                        }}
-                    >
-                        <Text>Badge</Text>
-                        <View
-                            style={{
-                                flexDirection: 'row',
-                                justifyContent: 'space-evenly',
-                                alignItems: 'center',
-                                marginTop: 24,
-                            }}
-                        >
-                            <Badge
-                                size={24}
-                                visible
-                                allowFontScaling={!DISABLE_FONT_SCALE}
-                                maxFontSizeMultiplier={MAX_FONT_SCALE}
-                            />
-                            <Badge
-                                size={24}
-                                visible
-                                allowFontScaling={!DISABLE_FONT_SCALE}
-                                maxFontSizeMultiplier={MAX_FONT_SCALE}
-                            >
-                                3
-                            </Badge>
-                            <Badge
-                                size={40}
-                                visible
-                                allowFontScaling={!DISABLE_FONT_SCALE}
-                                maxFontSizeMultiplier={MAX_FONT_SCALE}
-                            >
-                                8
-                            </Badge>
-                            <Badge size={24} visible />
-                            <Badge size={24} visible>
-                                3
-                            </Badge>
-                            <Badge size={40} visible>
-                                8
-                            </Badge>
                         </View>
                     </View>
                 </Card>

--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -251,6 +251,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                             </Badge>
                         </View>
                     </View>
+                </Card>
+                <Card style={styles.card}>
                     <Card.Title title="Progress Bar" />
                     <ProgressBar progress={0.5} style={{ margin: 8 }} />
                 </Card>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-4901

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- feature/4901-badge-wrapper-example

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Simulator Screenshot - iphone 12 pro - 2023-11-20 at 16 51 47](https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/120575281/ef516f4c-ce85-42d0-a6c5-cc4c87b44642)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- Please merge this PR, once https://github.com/etn-ccis/blui-react-native-component-library/pull/438 gets merged.
