### PR TITLE
Add examples for fontsize

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -410,7 +410,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <Card.Title title="Overline" />
                 <Card.Content>
                     <Overline>Overline</Overline>
-                    <Text style={{marginTop: 12}}> FontSize 14 </Text>
+                    <Text style={{ marginTop: 12 }}> FontSize 14 </Text>
                     <Overline fontSize={14}>Overline</Overline>
                 </Card.Content>
             </Card>
@@ -435,7 +435,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     {/* Font size : 14px */}
                     <ChannelValue value="2.5:1" icon={{ name: 'settings' }} fontSize={14} style={{ marginTop: 12 }} />
                     {/* Font size : 16px */}
-                    <ChannelValue value="Concord" icon={'🍇'} fontSize={14} style={{ marginTop: 12 }} />
+                    <ChannelValue value="Concord" icon={'🍇'} fontSize={16} style={{ marginTop: 12 }} />
                     {/* Font size : 22px */}
                     <ChannelValue
                         value="100"
@@ -471,13 +471,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         fontSize={14}
                     />
                     {/* Font size : 22px */}
-                    <Text style={{marginTop: 12}}>Font size : 22px</Text>
-                    <ListItemTag
-                        label={'Foo Bar'}
-                        backgroundColor={'red'}
-                        fontColor={'black'}
-                        fontSize={22}
-                    />
+                    <Text style={{ marginTop: 12 }}>Font size : 22px</Text>
+                    <ListItemTag label={'Foo Bar'} backgroundColor={'red'} fontColor={'black'} fontSize={22} />
                 </Card.Content>
             </Card>
             <Card style={styles.card}>

--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -410,6 +410,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <Card.Title title="Overline" />
                 <Card.Content>
                     <Overline>Overline</Overline>
+                    <Text style={{marginTop: 12}}> FontSize 14 </Text>
+                    <Overline fontSize={14}>Overline</Overline>
                 </Card.Content>
             </Card>
             <Card style={styles.card}>
@@ -469,11 +471,11 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         fontSize={14}
                     />
                     {/* Font size : 22px */}
+                    <Text style={{marginTop: 12}}>Font size : 22px</Text>
                     <ListItemTag
                         label={'Foo Bar'}
                         backgroundColor={'red'}
                         fontColor={'black'}
-                        style={{ marginTop: 12 }}
                         fontSize={22}
                     />
                 </Card.Content>

--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -245,7 +245,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                                 <DrawerNavItem
                                     itemID={'item4'}
                                     title={'Localization'}
-                                    icon={{ family: 'material-community', name: 'circle' }}
+                                    icon={{ family: 'material-community', name: 'circle', direction: 'auto' }}
                                     activeItemBackgroundShape={'round'}
                                     InfoListItemProps={{
                                         iconAlign: 'center',
@@ -430,11 +430,11 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         icon={{ family: 'brightlayer-ui', name: 'device' }}
                         iconColor="green"
                     />
-                    {/* Default Font size : 14px */}
+                    {/* Font size : 14px */}
                     <ChannelValue value="2.5:1" icon={{ name: 'settings' }} fontSize={14} style={{ marginTop: 12 }} />
-                    {/* Default Font size : 16px */}
-                    <ChannelValue value="Concord" icon={'🍇'} style={{ marginTop: 12 }} />
-                    {/* Default Font size : 22px */}
+                    {/* Font size : 16px */}
+                    <ChannelValue value="Concord" icon={'🍇'} fontSize={14} style={{ marginTop: 12 }} />
+                    {/* Font size : 22px */}
                     <ChannelValue
                         value="100"
                         units="%"
@@ -442,7 +442,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         icon={{ family: 'brightlayer-ui', name: 'battery' }}
                         style={{ marginTop: 12 }}
                     />
-                    {/* Default Font size : 32px */}
+                    {/* Font size : 32px */}
                     <ChannelValue
                         value="50.2.1"
                         fontSize={32}
@@ -450,19 +450,31 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         iconColor="red"
                         style={{ marginTop: 12 }}
                     />
-                    <ChannelValue value="1" icon={'A'} iconColor="blue" style={{ marginTop: 12 }} />
-                    <ChannelValue value="1" icon={PublicDomainAlice} fontSize={32} style={{ marginTop: 12 }} />
+                    {/* Font size : 32px */}
+                    <ChannelValue value="1" icon={'A'} iconColor="blue" fontSize={32} style={{ marginTop: 12 }} />
+                    <ChannelValue value="1" icon={PublicDomainAlice} style={{ marginTop: 12 }} />
                 </Card.Content>
             </Card>
             <Card style={styles.card}>
                 <Card.Title title="ListItemTag" />
                 <Card.Content style={{ alignItems: 'center' }}>
+                    {/* Font size : 10px */}
                     <ListItemTag label={'IN PROGRESS'} />
+                    {/* Font size : 14px */}
                     <ListItemTag
                         label={'Foo Bar'}
                         backgroundColor={'red'}
                         fontColor={'black'}
                         style={{ marginTop: 12 }}
+                        fontSize={14}
+                    />
+                    {/* Font size : 22px */}
+                    <ListItemTag
+                        label={'Foo Bar'}
+                        backgroundColor={'red'}
+                        fontColor={'black'}
+                        style={{ marginTop: 12 }}
+                        fontSize={22}
                     />
                 </Card.Content>
             </Card>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes 4961 .
Issue [435](https://github.com/etn-ccis/blui-react-native-component-library/issues/435)

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Add examples for ChannelValue, ListItemTag, and Overline components with fontSize prop.
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<img width="382" alt="Screenshot 2023-11-27 at 6 29 15 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/133877691/a8ee3a12-d082-4485-8401-a97aa5419e3d">
<img width="380" alt="Screenshot 2023-11-27 at 7 02 04 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/133877691/cd0c0e60-1172-4cae-8696-9e6db1ee6df5">
<img width="364" alt="Screenshot 2023-11-27 at 7 03 49 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/133877691/fff9c326-ad04-425f-86e8-2288d5ceec7e">



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
