### PR TITLE
Feature/blui 5010 add button variants

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -1121,7 +1121,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="contained"
-                        buttonColor={BLUIColors.error[40]}
+                        buttonColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1130,7 +1130,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained"
-                        buttonColor={BLUIColors.error[40]}
+                        buttonColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1139,7 +1139,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained"
-                        buttonColor={BLUIColors.error[40]}
+                        buttonColor={theme.colors.error}
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
@@ -1186,7 +1186,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="outlined"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Outlined Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1195,7 +1195,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="outlined"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Outlined Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1204,7 +1204,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="outlined"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Outlined Button')}
                         style={{ marginTop: 24 }}
@@ -1251,7 +1251,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="text"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Text Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1260,7 +1260,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="text"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Text Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1269,7 +1269,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="text"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Text Button')}
                         style={{ marginTop: 24 }}
@@ -1316,7 +1316,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="elevated"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Elevated Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1325,7 +1325,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="elevated"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Elevated Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1334,7 +1334,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="elevated"
-                        textColor={BLUIColors.error[40]}
+                        textColor={theme.colors.error}
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Elevated Button')}
                         style={{ marginTop: 24 }}
@@ -1385,8 +1385,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="contained-tonal"
-                        buttonColor={BLUIColors.error[90]}
-                        textColor={BLUIColors.error[30]}
+                        buttonColor={theme.colors.errorContainer}
+                        textColor={theme.colors.onErrorContainer}
                         onPress={(): void => console.log('Pressed Contained-tonal Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1395,8 +1395,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained-tonal"
-                        buttonColor={BLUIColors.error[90]}
-                        textColor={BLUIColors.error[30]}
+                        buttonColor={theme.colors.errorContainer}
+                        textColor={theme.colors.onErrorContainer}
                         onPress={(): void => console.log('Pressed Contained-tonal Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1405,8 +1405,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained-tonal"
-                        buttonColor={BLUIColors.error[90]}
-                        textColor={BLUIColors.error[30]}
+                        buttonColor={theme.colors.errorContainer}
+                        textColor={theme.colors.onErrorContainer}
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Contained-tonal Button')}
                         style={{ marginTop: 24 }}

--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -1103,23 +1103,16 @@ export const KitchenSink: React.FC = (): JSX.Element => {
             <Card style={{ padding: 20, margin: 10 }}>
                 <Text>Contained Button</Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="contained"
-                        onPress={(): void => console.log('Pressed Contained Button')}
-                    >
+                    <Button mode="contained" onPress={(): void => console.log('Pressed Contained Button')}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="contained" onPress={(): void => console.log('Pressed Contained Button')}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="contained"
-                        onPress={(): void => console.log('Pressed Contained Button')}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="contained"
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Contained Button')}
                     >
                         Label
@@ -1128,7 +1121,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="contained"
-                        buttonColor='red'
+                        buttonColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1137,7 +1130,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained"
-                        buttonColor='red'
+                        buttonColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1146,8 +1139,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained"
-                        buttonColor='red'
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        buttonColor={BLUIColors.error[40]}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1155,26 +1148,17 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="contained"
-                        disabled
-                        style={{ marginTop: 24 }}
-                    >
+                    <Button mode="contained" disabled style={{ marginTop: 24 }}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="contained" disabled style={{ marginTop: 24 }}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="contained"
                         disabled
-                        style={{ marginTop: 24 }}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="contained"
-                        disabled
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         style={{ marginTop: 24 }}
                     >
                         Label
@@ -1184,23 +1168,16 @@ export const KitchenSink: React.FC = (): JSX.Element => {
             <Card style={{ padding: 20, margin: 10 }}>
                 <Text>Outlined Button</Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="outlined"
-                        onPress={(): void => console.log('Pressed Outlined Button')}
-                    >
+                    <Button mode="outlined" onPress={(): void => console.log('Pressed Outlined Button')}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="outlined" onPress={(): void => console.log('Pressed Outlined Button')}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="outlined"
-                        onPress={(): void => console.log('Pressed Outlined Button')}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="outlined"
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Outlined Button')}
                     >
                         Label
@@ -1209,7 +1186,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="outlined"
-                        textColor='red'
+                        textColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Outlined Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1218,7 +1195,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="outlined"
-                        textColor='red'
+                        textColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Outlined Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1227,8 +1204,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="outlined"
-                        textColor='red'
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        textColor={BLUIColors.error[40]}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Outlined Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1236,26 +1213,17 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="outlined"
-                        disabled
-                        style={{ marginTop: 24 }}
-                    >
+                    <Button mode="outlined" disabled style={{ marginTop: 24 }}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="outlined" disabled style={{ marginTop: 24 }}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="outlined"
                         disabled
-                        style={{ marginTop: 24 }}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="outlined"
-                        disabled
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         style={{ marginTop: 24 }}
                     >
                         Label
@@ -1265,23 +1233,16 @@ export const KitchenSink: React.FC = (): JSX.Element => {
             <Card style={{ padding: 20, margin: 10 }}>
                 <Text>Text Button</Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="text"
-                        onPress={(): void => console.log('Pressed Text Button')}
-                    >
+                    <Button mode="text" onPress={(): void => console.log('Pressed Text Button')}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="text" onPress={(): void => console.log('Pressed Text Button')}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="text"
-                        onPress={(): void => console.log('Pressed Text Button')}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="text"
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Text Button')}
                     >
                         Label
@@ -1290,7 +1251,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="text"
-                        textColor='red'
+                        textColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Text Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1299,7 +1260,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="text"
-                        textColor='red'
+                        textColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Text Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1308,8 +1269,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="text"
-                        textColor='red'
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        textColor={BLUIColors.error[40]}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Text Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1317,26 +1278,17 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="text"
-                        disabled
-                        style={{ marginTop: 24 }}
-                    >
+                    <Button mode="text" disabled style={{ marginTop: 24 }}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="text" disabled style={{ marginTop: 24 }}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="text"
                         disabled
-                        style={{ marginTop: 24 }}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="text"
-                        disabled
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         style={{ marginTop: 24 }}
                     >
                         Label
@@ -1346,23 +1298,16 @@ export const KitchenSink: React.FC = (): JSX.Element => {
             <Card style={{ padding: 20, margin: 10 }}>
                 <Text>Elevated Button</Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="elevated"
-                        onPress={(): void => console.log('Pressed Elevated Button')}
-                    >
+                    <Button mode="elevated" onPress={(): void => console.log('Pressed Elevated Button')}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="elevated" onPress={(): void => console.log('Pressed Elevated Button')}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="elevated"
-                        onPress={(): void => console.log('Pressed Elevated Button')}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="elevated"
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Elevated Button')}
                     >
                         Label
@@ -1371,7 +1316,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="elevated"
-                        textColor='red'
+                        textColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Elevated Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1380,7 +1325,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="elevated"
-                        textColor='red'
+                        textColor={BLUIColors.error[40]}
                         onPress={(): void => console.log('Pressed Elevated Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1389,8 +1334,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="elevated"
-                        textColor='red'
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        textColor={BLUIColors.error[40]}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Elevated Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1398,26 +1343,17 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="elevated"
-                        disabled
-                        style={{ marginTop: 24 }}
-                    >
+                    <Button mode="elevated" disabled style={{ marginTop: 24 }}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="elevated" disabled style={{ marginTop: 24 }}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="elevated"
                         disabled
-                        style={{ marginTop: 24 }}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="elevated"
-                        disabled
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         style={{ marginTop: 24 }}
                     >
                         Label
@@ -1427,10 +1363,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
             <Card style={{ padding: 20, margin: 10 }}>
                 <Text>Contained-Tonal Button</Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="contained-tonal"
-                        onPress={(): void => console.log('Pressed Contained-tonal Button')}
-                    >
+                    <Button mode="contained-tonal" onPress={(): void => console.log('Pressed Contained-tonal Button')}>
                         Label
                     </Button>
                     <Button
@@ -1443,7 +1376,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained-tonal"
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Contained-tonal Button')}
                     >
                         Label
@@ -1452,7 +1385,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
                         mode="contained-tonal"
-                        buttonColor='red'
+                        buttonColor={BLUIColors.error[90]}
+                        textColor={BLUIColors.error[30]}
                         onPress={(): void => console.log('Pressed Contained-tonal Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1461,7 +1395,8 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained-tonal"
-                        buttonColor='red'
+                        buttonColor={BLUIColors.error[90]}
+                        textColor={BLUIColors.error[30]}
                         onPress={(): void => console.log('Pressed Contained-tonal Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1470,8 +1405,9 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         icon="plus"
                         mode="contained-tonal"
-                        buttonColor='red'
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        buttonColor={BLUIColors.error[90]}
+                        textColor={BLUIColors.error[30]}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Contained-tonal Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1479,26 +1415,17 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        mode="contained-tonal"
-                        disabled
-                        style={{ marginTop: 24 }}
-                    >
+                    <Button mode="contained-tonal" disabled style={{ marginTop: 24 }}>
+                        Label
+                    </Button>
+                    <Button icon="plus" mode="contained-tonal" disabled style={{ marginTop: 24 }}>
                         Label
                     </Button>
                     <Button
                         icon="plus"
                         mode="contained-tonal"
                         disabled
-                        style={{ marginTop: 24 }}
-                    >
-                        Label
-                    </Button>
-                    <Button
-                        icon="plus"
-                        mode="contained-tonal"
-                        disabled
-                        contentStyle={{flexDirection: 'row-reverse'}}
+                        contentStyle={{ flexDirection: 'row-reverse' }}
                         style={{ marginTop: 24 }}
                     >
                         Label

--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -1101,123 +1101,407 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 </View>
             </Card>
             <Card style={{ padding: 20, margin: 10 }}>
-                <Text>Button</Text>
+                <Text>Contained Button</Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
-                        icon="download"
-                        mode="text"
-                        onPress={(): void => console.log('Pressed Text Button')}
-                        style={{ width: 150 }}
+                        mode="contained"
+                        onPress={(): void => console.log('Pressed Contained Button')}
                     >
-                        Press me
+                        Label
                     </Button>
                     <Button
-                        icon="download"
-                        mode="text"
-                        onPress={(): void => console.log('Pressed Text Button')}
-                        style={{ width: 150 }}
+                        icon="plus"
+                        mode="contained"
+                        onPress={(): void => console.log('Pressed Contained Button')}
                     >
-                        Press me
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained"
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Contained Button')}
+                    >
+                        Label
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
-                        icon="download"
-                        mode="outlined"
-                        onPress={(): void => console.log('Pressed Outlined Button')}
-                        style={{ marginTop: 24, width: 150 }}
+                        mode="contained"
+                        buttonColor='red'
+                        onPress={(): void => console.log('Pressed Contained Button')}
+                        style={{ marginTop: 24 }}
                     >
-                        Press me
+                        Label
                     </Button>
                     <Button
-                        icon="download"
-                        mode="outlined"
-                        onPress={(): void => console.log('Pressed Outlined Button')}
-                        style={{ marginTop: 24, width: 150 }}
+                        icon="plus"
+                        mode="contained"
+                        buttonColor='red'
+                        onPress={(): void => console.log('Pressed Contained Button')}
+                        style={{ marginTop: 24 }}
                     >
-                        Press me
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained"
+                        buttonColor='red'
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Contained Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
-                        icon="download"
                         mode="contained"
-                        onPress={(): void => console.log('Pressed Contained Button')}
-                        style={{ marginTop: 24, width: 150 }}
+                        disabled
+                        style={{ marginTop: 24 }}
                     >
-                        Press me
+                        Label
                     </Button>
                     <Button
-                        icon="download"
+                        icon="plus"
                         mode="contained"
-                        onPress={(): void => console.log('Pressed Contained Button')}
-                        style={{ marginTop: 24, width: 150 }}
+                        disabled
+                        style={{ marginTop: 24 }}
                     >
-                        Press me
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained"
+                        disabled
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
                     </Button>
                 </View>
             </Card>
             <Card style={{ padding: 20, margin: 10 }}>
-                <Text>Button(Disabled)</Text>
+                <Text>Outlined Button</Text>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
-                        icon="download"
-                        mode="text"
-                        onPress={(): void => console.log('Pressed Text Button')}
-                        style={{ width: 150 }}
-                        disabled
-                    >
-                        Press me
-                    </Button>
-                    <Button
-                        icon="download"
-                        mode="text"
-                        onPress={(): void => console.log('Pressed Text Button')}
-                        style={{ width: 150 }}
-                        disabled
-                    >
-                        Press me
-                    </Button>
-                </View>
-
-                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button
-                        icon="download"
                         mode="outlined"
                         onPress={(): void => console.log('Pressed Outlined Button')}
-                        style={{ marginTop: 24, width: 150 }}
-                        disabled
                     >
-                        Press me
+                        Label
                     </Button>
                     <Button
-                        icon="download"
+                        icon="plus"
                         mode="outlined"
                         onPress={(): void => console.log('Pressed Outlined Button')}
-                        style={{ marginTop: 24, width: 150 }}
-                        disabled
                     >
-                        Press me
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="outlined"
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Outlined Button')}
+                    >
+                        Label
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                     <Button
-                        icon="download"
-                        mode="contained"
-                        onPress={(): void => console.log('Pressed Contained Button')}
-                        style={{ marginTop: 24, width: 150 }}
-                        disabled
+                        mode="outlined"
+                        textColor='red'
+                        onPress={(): void => console.log('Pressed Outlined Button')}
+                        style={{ marginTop: 24 }}
                     >
-                        Press me
+                        Label
                     </Button>
                     <Button
-                        icon="download"
-                        mode="contained"
-                        onPress={(): void => console.log('Pressed Contained Button')}
-                        style={{ marginTop: 24, width: 150 }}
-                        disabled
+                        icon="plus"
+                        mode="outlined"
+                        textColor='red'
+                        onPress={(): void => console.log('Pressed Outlined Button')}
+                        style={{ marginTop: 24 }}
                     >
-                        Press me
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="outlined"
+                        textColor='red'
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Outlined Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="outlined"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="outlined"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="outlined"
+                        disabled
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                </View>
+            </Card>
+            <Card style={{ padding: 20, margin: 10 }}>
+                <Text>Text Button</Text>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="text"
+                        onPress={(): void => console.log('Pressed Text Button')}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="text"
+                        onPress={(): void => console.log('Pressed Text Button')}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="text"
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Text Button')}
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="text"
+                        textColor='red'
+                        onPress={(): void => console.log('Pressed Text Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="text"
+                        textColor='red'
+                        onPress={(): void => console.log('Pressed Text Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="text"
+                        textColor='red'
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Text Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="text"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="text"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="text"
+                        disabled
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                </View>
+            </Card>
+            <Card style={{ padding: 20, margin: 10 }}>
+                <Text>Elevated Button</Text>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="elevated"
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="elevated"
+                        textColor='red'
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        textColor='red'
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        textColor='red'
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="elevated"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        disabled
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                </View>
+            </Card>
+            <Card style={{ padding: 20, margin: 10 }}>
+                <Text>Contained-Tonal Button</Text>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="contained-tonal"
+                        onPress={(): void => console.log('Pressed Contained-tonal Button')}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained-tonal"
+                        onPress={(): void => console.log('Pressed Contained-tonal Button')}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained-tonal"
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Contained-tonal Button')}
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="contained-tonal"
+                        buttonColor='red'
+                        onPress={(): void => console.log('Pressed Contained-tonal Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained-tonal"
+                        buttonColor='red'
+                        onPress={(): void => console.log('Pressed Contained-tonal Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained-tonal"
+                        buttonColor='red'
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        onPress={(): void => console.log('Pressed Contained-tonal Button')}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                    <Button
+                        mode="contained-tonal"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained-tonal"
+                        disabled
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
+                    </Button>
+                    <Button
+                        icon="plus"
+                        mode="contained-tonal"
+                        disabled
+                        contentStyle={{flexDirection: 'row-reverse'}}
+                        style={{ marginTop: 24 }}
+                    >
+                        Label
                     </Button>
                 </View>
             </Card>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes https://github.com/etn-ccis/blui-react-native-showcase-demo/issues/124

Fixes BLUI-5010. Add more button variants

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- add button examples
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="379" alt="image" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/119693939/fcddc041-68c9-4929-a87d-7d4c2bc7b28f">
<img width="382" alt="image" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/119693939/c9a7cc83-9983-4d0d-b817-ac7f6a2b5501">
<img width="382" alt="image" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/119693939/804709ae-6b24-4d2c-b17b-89f26453f8a1">



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- git clone https://github.com/etn-ccis/blui-react-native-component-library.git
- git checkout release/md3
- yarn initialize
- cd demos/showcase
- git checkout feature/blui-5010-add-button-variants
- cd ../..
- yarn start:showcase-ios
- If you want to review the disabled buttons git clone https://github.com/etn-ccis/blui-react-native-themes.git
- git checkout feature/update-disabled-variants
- yarn && yarn build
- copy contents from dist to showcase dist

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- disabled colors update here in this PR - https://github.com/etn-ccis/blui-react-native-themes/pull/68
