### PR TITLE
Updated next button color in mobile stepper example

### DIFF
--- a/components/MobileStepperExample.tsx
+++ b/components/MobileStepperExample.tsx
@@ -53,7 +53,6 @@ export const MobileStepperExample: React.FC = () => {
         rightButton: {
             alignSelf: 'flex-end',
             backgroundColor: disabledContainer,
-            color: onDisabledContainer,
         },
     });
 
@@ -84,6 +83,7 @@ export const MobileStepperExample: React.FC = () => {
                         disabled={currentStep === totalSteps - 1}
                         onPress={(): void => updateStep(1)}
                         mode="contained"
+                        textColor={onDisabledContainer}
                     >
                         Next
                     </Button>

--- a/components/MobileStepperExample.tsx
+++ b/components/MobileStepperExample.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { StyleSheet, Text } from 'react-native';
-import { MobileStepper, DotStepperVariant } from '@brightlayer-ui/react-native-components';
+import { MobileStepper, DotStepperVariant, useAppTheme } from '@brightlayer-ui/react-native-components';
 import { Button, Card, Divider, useTheme } from 'react-native-paper';
 import * as BLUIColors from '@brightlayer-ui/colors';
 
@@ -9,6 +9,9 @@ export const MobileStepperExample: React.FC = () => {
     const totalSteps = 5;
     const [currentStep, setCurrentStep] = useState(0);
     const [mobileStepperVariant, setMobileStepperVariant] = useState<DotStepperVariant>('dots');
+    const {
+        colors: { disabledContainer, onDisabledContainer },
+    } = useAppTheme();
 
     const updateStep = useCallback(
         (delta: number): void => {
@@ -49,6 +52,8 @@ export const MobileStepperExample: React.FC = () => {
         },
         rightButton: {
             alignSelf: 'flex-end',
+            backgroundColor: disabledContainer,
+            color: onDisabledContainer,
         },
     });
 

--- a/components/MobileStepperExample.tsx
+++ b/components/MobileStepperExample.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { StyleSheet, Text } from 'react-native';
-import { MobileStepper, DotStepperVariant, useAppTheme } from '@brightlayer-ui/react-native-components';
+import { MobileStepper, DotStepperVariant } from '@brightlayer-ui/react-native-components';
 import { Button, Card, Divider, useTheme } from 'react-native-paper';
 import * as BLUIColors from '@brightlayer-ui/colors';
 
@@ -9,9 +9,6 @@ export const MobileStepperExample: React.FC = () => {
     const totalSteps = 5;
     const [currentStep, setCurrentStep] = useState(0);
     const [mobileStepperVariant, setMobileStepperVariant] = useState<DotStepperVariant>('dots');
-    const {
-        colors: { disabledContainer, onDisabledContainer },
-    } = useAppTheme();
 
     const updateStep = useCallback(
         (delta: number): void => {
@@ -52,7 +49,6 @@ export const MobileStepperExample: React.FC = () => {
         },
         rightButton: {
             alignSelf: 'flex-end',
-            backgroundColor: disabledContainer,
         },
     });
 
@@ -83,7 +79,8 @@ export const MobileStepperExample: React.FC = () => {
                         disabled={currentStep === totalSteps - 1}
                         onPress={(): void => updateStep(1)}
                         mode="contained"
-                        textColor={onDisabledContainer}
+                        buttonColor={currentStep === totalSteps - 1 ? theme.colors.disabledContainer : undefined}
+                        textColor={currentStep === totalSteps - 1 ? theme.colors.onDisabledContainer : undefined}
                     >
                         Next
                     </Button>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #143 BLUI-5004

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added next button disabled color in Mobile stepper to be disabledContainer and onDisabledContainer

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

![Simulator Screenshot - iphone 12 pro - 2023-12-14 at 16 36 12](https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/120575281/c959565b-1c08-4158-a17d-8bdb09ec15ba)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Checkout bug/5004-143-update-disabled-button-colors branch in component library
- yarn ios

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- Merge https://github.com/etn-ccis/blui-react-native-component-library/pull/468 before merging this.
