### PR TITLE
Removed style overrides of mobile stepper right button and chip example width fixes

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -196,7 +196,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
 
             <Card style={styles.card}>
                 <Card.Title title="Chip" />
-                <Card.Content>
+                <Card.Content style={{ alignItems: 'flex-start' }}>
                     <Chip style={{ marginTop: 10 }}>Outlined Chip</Chip>
                     <Chip
                         icon={{ name: 'info' }}

--- a/components/MobileStepperExample.tsx
+++ b/components/MobileStepperExample.tsx
@@ -78,8 +78,6 @@ export const MobileStepperExample: React.FC = () => {
                         disabled={currentStep === totalSteps - 1}
                         onPress={(): void => updateStep(1)}
                         mode="contained"
-                        buttonColor={currentStep === totalSteps - 1 ? theme.colors.disabledContainer : undefined}
-                        textColor={currentStep === totalSteps - 1 ? theme.colors.onDisabledContainer : undefined}
                     >
                         Next
                     </Button>


### PR DESCRIPTION
…le width fixes

<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .
Reverted the overrides in the showcase, which have already been fixed with the latest themes update

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Removed color overrides of mobile stepper right button
- Added align items flex start to chip card 

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Simulator Screenshot - iphone 12 pro - 2023-12-22 at 14 29 20](https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/120575281/cfc42668-7f58-4f8b-8b1b-e8acf16c444f)

![Simulator Screenshot - iphone 12 pro - 2023-12-22 at 14 47 47](https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/120575281/743bba9f-21b0-4071-baec-a400278db085)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
