### PR TITLE
Fixed icons of BottomNavigation component

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -123,15 +123,14 @@ export const KitchenSink: React.FC = (): JSX.Element => {
     const helperTextInputHasErrors = (): boolean => !helperTextInputText.includes('@');
 
     const [routes] = React.useState([
-        { key: 'music', title: 'Music', icon: 'music', color: 'red', badge: true },
+        { key: 'music', title: 'Music', focusedIcon: 'music', badge: true },
         {
             key: 'albums',
             title: 'Albums',
-            icon: 'album',
-            color: 'orange',
+            focusedIcon: 'album',
             badge: '1',
         },
-        { key: 'recents', title: 'Recents', icon: 'history', color: 'yellow' },
+        { key: 'recents', title: 'Recents', focusedIcon: 'history' },
     ]);
 
     const renderScene = BottomNavigation.SceneMap({


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes 5083.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fixed issue [65](https://github.com/etn-ccis/blui-react-native-themes/issues/65)
- In React Native paper 5  Icon prop is renamed as focusedIcon
- Color prop is deprecated in React Native Paper 5

https://callstack.github.io/react-native-paper/docs/guides/migration-guide-to-5.0/#bottomnavigation-navigation-bar

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="352" alt="Screenshot 2023-12-28 at 10 09 07 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/133877691/32fe0c12-d186-4bc2-86c8-9f2c46361484">

<img width="342" alt="Screenshot 2023-12-28 at 10 15 26 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/133877691/dec3f0e0-7247-4f4b-9606-4e7ef5af5516">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
