### PR TITLE
Fix background color for elevated button

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -1699,11 +1699,20 @@ export const KitchenSink: React.FC = (): JSX.Element => {
             </Card>
             <Card style={{ padding: 20, margin: 10 }}>
                 <Text>Elevated Button</Text>
-                <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button mode="elevated" onPress={(): void => console.log('Pressed Elevated Button')}>
+                <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 10 }}>
+                    <Button
+                        mode="elevated"
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                        buttonColor={theme.colors.surfaceContainerLow}
+                    >
                         Label
                     </Button>
-                    <Button icon="plus" mode="elevated" onPress={(): void => console.log('Pressed Elevated Button')}>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        onPress={(): void => console.log('Pressed Elevated Button')}
+                        buttonColor={theme.colors.surfaceContainerLow}
+                    >
                         Label
                     </Button>
                     <Button
@@ -1711,6 +1720,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         mode="elevated"
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Elevated Button')}
+                        buttonColor={theme.colors.surfaceContainerLow}
                     >
                         Label
                     </Button>
@@ -1720,6 +1730,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         mode="elevated"
                         textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Elevated Button')}
+                        buttonColor={theme.colors.surfaceContainerLow}
                         style={{ marginTop: 24 }}
                     >
                         Label
@@ -1729,6 +1740,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         mode="elevated"
                         textColor={theme.colors.error}
                         onPress={(): void => console.log('Pressed Elevated Button')}
+                        buttonColor={theme.colors.surfaceContainerLow}
                         style={{ marginTop: 24 }}
                     >
                         Label
@@ -1739,16 +1751,28 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         textColor={theme.colors.error}
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Elevated Button')}
+                        buttonColor={theme.colors.surfaceContainerLow}
                         style={{ marginTop: 24 }}
                     >
                         Label
                     </Button>
                 </View>
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Button mode="elevated" disabled style={{ marginTop: 24 }}>
+                    <Button
+                        mode="elevated"
+                        disabled
+                        style={{ marginTop: 24 }}
+                        buttonColor={theme.colors.surfaceContainerLow}
+                    >
                         Label
                     </Button>
-                    <Button icon="plus" mode="elevated" disabled style={{ marginTop: 24 }}>
+                    <Button
+                        icon="plus"
+                        mode="elevated"
+                        disabled
+                        style={{ marginTop: 24 }}
+                        buttonColor={theme.colors.surfaceContainerLow}
+                    >
                         Label
                     </Button>
                     <Button
@@ -1757,6 +1781,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         disabled
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         style={{ marginTop: 24 }}
+                        buttonColor={theme.colors.surfaceContainerLow}
                     >
                         Label
                     </Button>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes 5085 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Used buttonColor prop to match figma design for elevated button
- Fixed [75](https://github.com/etn-ccis/blui-react-native-showcase-demo/issues/167)
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="364" alt="Screenshot 2023-12-28 at 11 20 00 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/133877691/5afe65a8-9387-433d-8f52-14e58d6e2da1">
<img width="367" alt="Screenshot 2023-12-28 at 11 20 10 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/133877691/9daeda61-8433-46a1-87e0-0415865595a5">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
