### PR TITLE
Removed elevated outline chip variant from kitchen sink

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -332,14 +332,6 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         Compact Outlined Chip
                     </Chip>
                     <Chip
-                        elevated
-                        style={{
-                            marginTop: 10,
-                        }}
-                    >
-                        Elevated Outlined Chip
-                    </Chip>
-                    <Chip
                         textStyle={{ color: BLUIColors.neutralVariant[50] }}
                         style={{
                             marginTop: 10,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #168 BLUI-5070

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Removed elevated outline chip variant

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

![Simulator Screenshot - iphone 12 pro - 2023-12-29 at 15 39 08](https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/120575281/66f3f9f1-3cc9-4f53-bf95-66caf50cc6ec)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn ios
- Scroll down to Chip component example

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
