### PR TITLE
Text field's error messages not in the correct position

### DIFF
--- a/components/TextInputExample.tsx
+++ b/components/TextInputExample.tsx
@@ -26,6 +26,10 @@ export const TextFieldExample: React.FC = () => {
         thinUnderline: {
             borderBottomWidth: 0, // Adjust the thickness as needed
         },
+        helperText: {
+            marginBottom: 8,
+            paddingHorizontal: 16,
+        },
     });
 
     return (
@@ -58,7 +62,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8 }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 
@@ -103,7 +107,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8 }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 
@@ -150,7 +154,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8 }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 
@@ -198,7 +202,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8 }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 
@@ -244,7 +248,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8, backgroundColor: 'transparent' }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 
@@ -290,7 +294,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8, backgroundColor: 'transparent' }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 
@@ -337,7 +341,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8, backgroundColor: 'transparent' }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 
@@ -385,7 +389,7 @@ export const TextFieldExample: React.FC = () => {
                     error={hasError}
                     style={{ marginHorizontal: 8, marginTop: 8, backgroundColor: 'transparent' }}
                 />
-                <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                <HelperText type="error" visible={hasError} style={styles.helperText}>
                     Error Message
                 </HelperText>
 

--- a/components/TextInputExample.tsx
+++ b/components/TextInputExample.tsx
@@ -28,6 +28,7 @@ export const TextFieldExample: React.FC = () => {
         },
         helperText: {
             marginBottom: 8,
+            marginHorizontal: 8,
             paddingHorizontal: 16,
         },
     });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #BLUI-5073 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added horizontal padding to the helper text, [154](https://github.com/etn-ccis/blui-react-native-showcase-demo/issues/154)

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

<img width="329" alt="Screenshot 2023-12-29 at 6 54 59 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/130662346/bc0e24ce-462c-44f8-b385-cac5f5ca27d1">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
