### PR TITLE
Fix Dark theme contained error button text color

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -1515,6 +1515,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                     <Button
                         mode="contained"
                         buttonColor={theme.colors.error}
+                        textColor={theme.colors.onError}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1524,6 +1525,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         icon="plus"
                         mode="contained"
                         buttonColor={theme.colors.error}
+                        textColor={theme.colors.onError}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}
                     >
@@ -1533,6 +1535,7 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                         icon="plus"
                         mode="contained"
                         buttonColor={theme.colors.error}
+                        textColor={theme.colors.onError}
                         contentStyle={{ flexDirection: 'row-reverse' }}
                         onPress={(): void => console.log('Pressed Contained Button')}
                         style={{ marginTop: 24 }}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #BLUI-5078 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added onError textColor to the Contained Button.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="301" alt="Screenshot 2024-01-02 at 4 34 23 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/130662346/94108a09-9cb4-4b49-810c-fca07f2dfd72">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
