### PR TITLE
Overridden actionIconColor prop of score card

### DIFF
--- a/components/ScoreCardExample.tsx
+++ b/components/ScoreCardExample.tsx
@@ -10,6 +10,7 @@ export const ScoreCardExample: React.FC = () => {
             headerTitle={'Substation 42'}
             headerSubtitle={'Normal'}
             headerInfo={'42 Devices'}
+            actionIconColor={BLUIColors.error[50]}
             actionItems={[{ icon: { name: 'star-outline' } }, { icon: { name: 'more-vert' }, onPress: () => {} }]}
             badgeOffset={-55}
             badge={


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-5089

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Overridden actionIconColor prop of ScoreCard

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Simulator Screenshot - iphone 12 pro - 2024-01-03 at 11 55 06](https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/120575281/11b45cf9-8b08-41bc-9f71-2b10937ad7db)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
- Checkout bug/5089-488-update-score-card-header-action-color branch in component library
- yarn start

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
