### PR TITLE
Removed overline example with fontSize prop override

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -788,8 +788,6 @@ export const KitchenSink: React.FC = (): JSX.Element => {
                 <Card.Title title="Overline" />
                 <Card.Content>
                     <Overline>Overline</Overline>
-                    <Text style={{ marginTop: 12 }}> FontSize 14 </Text>
-                    <Overline fontSize={14}>Overline</Overline>
                 </Card.Content>
             </Card>
             <Card style={styles.card}>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-5082

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Removed overline example with fontSize prop override

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Simulator Screenshot - iphone 12 pro - 2024-01-03 at 12 04 30](https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/120575281/86d88187-c7c3-403d-b586-ca1009dce5f5)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Checkout feature/5082-overline-props-refactor branch in component library
- yarn start

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
