### PR TITLE
Include RNP's "Segmented Button" in the showcase

### DIFF
--- a/components/KitchenSink.tsx
+++ b/components/KitchenSink.tsx
@@ -30,6 +30,7 @@ import {
     ProgressBar,
     Snackbar,
     ActivityIndicator,
+    SegmentedButtons,
 } from 'react-native-paper';
 import { DISABLE_FONT_SCALE, MAX_FONT_SCALE } from '../constants';
 import {
@@ -189,11 +190,77 @@ export const KitchenSink: React.FC = (): JSX.Element => {
     const showModal = (): void => setVisible(true);
     const hideModal = (): void => setVisible(false);
 
+    const [text, setText] = useState('');
+    const [icon, setIcon] = React.useState('');
+    const [value, setValue] = React.useState('');
+
     return (
         <>
             <Text variant="titleLarge" style={{ marginVertical: 48 }}>
                 MD3 BLUI Components
             </Text>
+            <Card style={styles.card}>
+                <Card.Title title="Segmented Buttons" />
+                <Card.Content>
+                    <SegmentedButtons
+                        value={text}
+                        onValueChange={setText}
+                        buttons={[
+                            {
+                                value: 'walk',
+                                label: 'Walking',
+                            },
+                            {
+                                value: 'train',
+                                label: 'Transit',
+                            },
+                            { value: 'drive', label: 'Driving' },
+                        ]}
+                        style={{ marginBottom: 20 }}
+                    />
+                    <SegmentedButtons
+                        value={icon}
+                        onValueChange={setIcon}
+                        buttons={[
+                            {
+                                value: 'walk',
+                                icon: 'walk',
+                            },
+                            {
+                                value: 'train',
+                                icon: 'train',
+                            },
+                            {
+                                value: 'drive',
+                                icon: 'car',
+                            },
+                        ]}
+                        style={{ marginBottom: 20 }}
+                    />
+                    <SegmentedButtons
+                        value={value}
+                        onValueChange={setValue}
+                        buttons={[
+                            {
+                                value: 'walk',
+                                label: 'Walking',
+                                icon: 'walk',
+                            },
+                            {
+                                value: 'train',
+                                label: 'Transit',
+                                icon: 'train',
+                            },
+                            {
+                                value: 'drive',
+                                label: 'Driving',
+                                icon: 'car',
+                            },
+                        ]}
+                        style={{ marginBottom: 10 }}
+                    />
+                </Card.Content>
+            </Card>
             <Card style={styles.card}>
                 <Card.Title title="Icon" />
                 <Card.Content>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #BLUI-5090 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added RNP Segmented Buttons example.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="311" alt="Screenshot 2024-01-03 at 5 02 16 PM" src="https://github.com/etn-ccis/blui-react-native-showcase-demo/assets/130662346/550be689-dce0-4aac-9cdb-5596a1ba2996">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
